### PR TITLE
fixed issue with table names not in lower case in postgresql

### DIFF
--- a/src/Laraue.EfCoreTriggers.PostgreSql/PostgreSqlProvider.cs
+++ b/src/Laraue.EfCoreTriggers.PostgreSql/PostgreSqlProvider.cs
@@ -116,7 +116,7 @@ namespace Laraue.EfCoreTriggers.PostgreSql
                 .Append(" RETURN NEW;END;")
                 .Append($"${trigger.Name}$ LANGUAGE plpgsql;")
                 .Append($"CREATE TRIGGER {trigger.Name} {GetTriggerTimeName(trigger.TriggerTime)} {trigger.TriggerEvent.ToString().ToUpper()} ")
-                .Append($"ON {GetTableName(typeof(TTriggerEntity))} FOR EACH ROW EXECUTE PROCEDURE {trigger.Name}();");
+                .Append($"ON \"{GetTableName(typeof(TTriggerEntity))}\" FOR EACH ROW EXECUTE PROCEDURE {trigger.Name}();");
         }
 
         protected override string GetNewGuidExpressionSql() => "uuid_generate_v4()";


### PR DESCRIPTION
Ef core reflects the classnames as Table names if not explicitly configured otherwise. Since Table names are not escaped on Trigger creations I had issues at runtime when a trigger got called on a Table with uppercase letters.

Fix: just adding quotes