### PR TITLE
Can use database keywords as column names

### DIFF
--- a/src/Laraue.EfCoreTriggers.Common/SqlGeneration/BaseExpressionProvider.cs
+++ b/src/Laraue.EfCoreTriggers.Common/SqlGeneration/BaseExpressionProvider.cs
@@ -29,6 +29,8 @@ namespace Laraue.EfCoreTriggers.Common.SqlGeneration
         /// </summary>
         protected virtual char Quote => '\'';
 
+        protected virtual char Delimiter => '"';
+
         /// <summary>
         /// Mappings between <see cref="Type">CLR Type</see> and SQL column types.
         /// Do not ask types directly from this property, use <see cref="GetSqlType"/> instead.

--- a/src/Laraue.EfCoreTriggers.Common/SqlGeneration/BaseSqlProvider.cs
+++ b/src/Laraue.EfCoreTriggers.Common/SqlGeneration/BaseSqlProvider.cs
@@ -101,7 +101,7 @@ namespace Laraue.EfCoreTriggers.Common.SqlGeneration
             if (assignmentParts.Any())
             {
                 sqlResult.Append("(")
-                    .AppendJoin(", ", assignmentParts.Select(x => GetColumnName(x.Key)))
+                    .AppendJoin(", ", assignmentParts.Select(x => $"{Delimiter}{GetColumnName(x.Key)}{Delimiter}"))
                     .Append(") VALUES (")
                     .AppendJoin(", ", assignmentParts.Select(x => x.Value.ToString()))
                     .Append(")");

--- a/src/Laraue.EfCoreTriggers.MySql/MySqlProvider.cs
+++ b/src/Laraue.EfCoreTriggers.MySql/MySqlProvider.cs
@@ -48,6 +48,8 @@ namespace Laraue.EfCoreTriggers.MySql
             AddConverter(new MathFloorConverter());
         }
 
+        protected override char Delimiter => '`';
+
         protected override Dictionary<Type, string> TypeMappings { get; } = new()
         {
             [typeof(bool)] = "BIT(1)",

--- a/tests/Laraue.EfCoreTriggers.MySqlTests/Unit/MySqlUnitMathFunctionsTests.cs
+++ b/tests/Laraue.EfCoreTriggers.MySqlTests/Unit/MySqlUnitMathFunctionsTests.cs
@@ -13,23 +13,23 @@ namespace Laraue.EfCoreTriggers.MySqlTests.Unit
         {
         }
         
-        public override string ExceptedAbsSql => "INSERT INTO destination_entities (decimal_value) VALUES (ABS(NEW.decimal_value));";
+        public override string ExceptedAbsSql => "INSERT INTO destination_entities (`decimal_value`) VALUES (ABS(NEW.decimal_value));";
 
-        public override string ExceptedAcosSql => "INSERT INTO destination_entities (double_value) VALUES (ACOS(NEW.double_value));";
+        public override string ExceptedAcosSql => "INSERT INTO destination_entities (`double_value`) VALUES (ACOS(NEW.double_value));";
 
-        public override string ExceptedAsinSql => "INSERT INTO destination_entities (double_value) VALUES (ASIN(NEW.double_value));";
+        public override string ExceptedAsinSql => "INSERT INTO destination_entities (`double_value`) VALUES (ASIN(NEW.double_value));";
 
-        public override string ExceptedAtanSql => "INSERT INTO destination_entities (double_value) VALUES (ATAN(NEW.double_value));";
+        public override string ExceptedAtanSql => "INSERT INTO destination_entities (`double_value`) VALUES (ATAN(NEW.double_value));";
 
-        public override string ExceptedAtan2Sql => "INSERT INTO destination_entities (double_value) VALUES (ATAN2(NEW.double_value, NEW.double_value));";
+        public override string ExceptedAtan2Sql => "INSERT INTO destination_entities (`double_value`) VALUES (ATAN2(NEW.double_value, NEW.double_value));";
 
-        public override string ExceptedCeilingSql => "INSERT INTO destination_entities (double_value) VALUES (CEILING(NEW.double_value));";
+        public override string ExceptedCeilingSql => "INSERT INTO destination_entities (`double_value`) VALUES (CEILING(NEW.double_value));";
         
-        public override string ExceptedCosSql => "INSERT INTO destination_entities (double_value) VALUES (COS(NEW.double_value));";
+        public override string ExceptedCosSql => "INSERT INTO destination_entities (`double_value`) VALUES (COS(NEW.double_value));";
 
-        public override string ExceptedExpSql => "INSERT INTO destination_entities (double_value) VALUES (EXP(NEW.double_value));";
+        public override string ExceptedExpSql => "INSERT INTO destination_entities (`double_value`) VALUES (EXP(NEW.double_value));";
       
-        public override string ExceptedFloorSql => "INSERT INTO destination_entities (double_value) VALUES (FLOOR(NEW.double_value));";
+        public override string ExceptedFloorSql => "INSERT INTO destination_entities (`double_value`) VALUES (FLOOR(NEW.double_value));";
 
     }
 }

--- a/tests/Laraue.EfCoreTriggers.MySqlTests/Unit/MySqlUnitMemberAssignmentFunctionsTests.cs
+++ b/tests/Laraue.EfCoreTriggers.MySqlTests/Unit/MySqlUnitMemberAssignmentFunctionsTests.cs
@@ -13,17 +13,17 @@ namespace Laraue.EfCoreTriggers.MySqlTests.Unit
         {
         }
 
-        public override string ExceptedEnumValueSql => "INSERT INTO destination_entities (enum_value) VALUES (NEW.enum_value);";
+        public override string ExceptedEnumValueSql => "INSERT INTO destination_entities (`enum_value`) VALUES (NEW.enum_value);";
 
-        public override string ExceptedDecimalAddSql => "INSERT INTO destination_entities (decimal_value) VALUES (NEW.decimal_value + 3);";
+        public override string ExceptedDecimalAddSql => "INSERT INTO destination_entities (`decimal_value`) VALUES (NEW.decimal_value + 3);";
 
-        public override string ExceptedDoubleSubSql => "INSERT INTO destination_entities (double_value) VALUES (NEW.double_value + 3);";
+        public override string ExceptedDoubleSubSql => "INSERT INTO destination_entities (`double_value`) VALUES (NEW.double_value + 3);";
 
-        public override string ExceptedIntMultiplySql => "INSERT INTO destination_entities (int_value) VALUES (NEW.int_value * 2);";
+        public override string ExceptedIntMultiplySql => "INSERT INTO destination_entities (`int_value`) VALUES (NEW.int_value * 2);";
 
-        public override string ExceptedBooleanSql => "INSERT INTO destination_entities (boolean_value) VALUES (NEW.boolean_value is false);";
+        public override string ExceptedBooleanSql => "INSERT INTO destination_entities (`boolean_value`) VALUES (NEW.boolean_value is false);";
 
-        public override string ExceptedNewGuidSql => "INSERT INTO destination_entities (guid_value) VALUES (UUID());";
+        public override string ExceptedNewGuidSql => "INSERT INTO destination_entities (`guid_value`) VALUES (UUID());";
 
     }
 }

--- a/tests/Laraue.EfCoreTriggers.MySqlTests/Unit/MySqlUnitStringFunctionsTests.cs
+++ b/tests/Laraue.EfCoreTriggers.MySqlTests/Unit/MySqlUnitStringFunctionsTests.cs
@@ -13,19 +13,19 @@ namespace Laraue.EfCoreTriggers.MySqlTests.Unit
         {
         }
 
-        public override string ExceptedConcatSql => "INSERT INTO destination_entities (string_field) VALUES (CONCAT(NEW.string_field, 'abc'));";
+        public override string ExceptedConcatSql => "INSERT INTO destination_entities (`string_field`) VALUES (CONCAT(NEW.string_field, 'abc'));";
 
-        public override string ExceptedStringLowerSql => "INSERT INTO destination_entities (string_field) VALUES (LOWER(NEW.string_field));";
+        public override string ExceptedStringLowerSql => "INSERT INTO destination_entities (`string_field`) VALUES (LOWER(NEW.string_field));";
 
-        public override string ExceptedStringUpperSql => "INSERT INTO destination_entities (string_field) VALUES (UPPER(NEW.string_field));";
+        public override string ExceptedStringUpperSql => "INSERT INTO destination_entities (`string_field`) VALUES (UPPER(NEW.string_field));";
 
-        public override string ExceptedStringTrimSql => "INSERT INTO destination_entities (string_field) VALUES (TRIM(NEW.string_field));";
+        public override string ExceptedStringTrimSql => "INSERT INTO destination_entities (`string_field`) VALUES (TRIM(NEW.string_field));";
 
-        public override string ExceptedContainsSql => "INSERT INTO destination_entities (boolean_value) VALUES (INSTR(NEW.string_field, 'abc') > 0);";
+        public override string ExceptedContainsSql => "INSERT INTO destination_entities (`boolean_value`) VALUES (INSTR(NEW.string_field, 'abc') > 0);";
 
-        public override string ExceptedEndsWithSql => "INSERT INTO destination_entities (boolean_value) VALUES (NEW.string_field LIKE CONCAT('%', 'abc'));";
+        public override string ExceptedEndsWithSql => "INSERT INTO destination_entities (`boolean_value`) VALUES (NEW.string_field LIKE CONCAT('%', 'abc'));";
 
-        public override string ExceptedIsNullOrEmptySql => "INSERT INTO destination_entities (boolean_value) VALUES (NEW.string_field IS NULL OR NEW.string_field = '');";
+        public override string ExceptedIsNullOrEmptySql => "INSERT INTO destination_entities (`boolean_value`) VALUES (NEW.string_field IS NULL OR NEW.string_field = '');";
 
     }
 }

--- a/tests/Laraue.EfCoreTriggers.PostgreSqlTests/Unit/PostgreSqlUnitMathFunctionsTests.cs
+++ b/tests/Laraue.EfCoreTriggers.PostgreSqlTests/Unit/PostgreSqlUnitMathFunctionsTests.cs
@@ -12,22 +12,22 @@ namespace Laraue.EfCoreTriggers.PostgreSqlTests.Unit
         public PostgreSqlUnitMathFunctionsTests() : base(new PostgreSqlProvider(new ContextFactory().CreateDbContext().Model))
         {
         }
-        public override string ExceptedAbsSql => "INSERT INTO destination_entities (decimal_value) VALUES (ABS(NEW.decimal_value));";
+        public override string ExceptedAbsSql => "INSERT INTO destination_entities (\"decimal_value\") VALUES (ABS(NEW.decimal_value));";
 
-        public override string ExceptedAcosSql => "INSERT INTO destination_entities (double_value) VALUES (ACOS(NEW.double_value));";
+        public override string ExceptedAcosSql => "INSERT INTO destination_entities (\"double_value\") VALUES (ACOS(NEW.double_value));";
 
-        public override string ExceptedAsinSql => "INSERT INTO destination_entities (double_value) VALUES (ASIN(NEW.double_value));";
+        public override string ExceptedAsinSql => "INSERT INTO destination_entities (\"double_value\") VALUES (ASIN(NEW.double_value));";
        
-        public override string ExceptedAtanSql => "INSERT INTO destination_entities (double_value) VALUES (ATAN(NEW.double_value));";
+        public override string ExceptedAtanSql => "INSERT INTO destination_entities (\"double_value\") VALUES (ATAN(NEW.double_value));";
         
-        public override string ExceptedAtan2Sql => "INSERT INTO destination_entities (double_value) VALUES (ATAN2(NEW.double_value, NEW.double_value));"; 
+        public override string ExceptedAtan2Sql => "INSERT INTO destination_entities (\"double_value\") VALUES (ATAN2(NEW.double_value, NEW.double_value));"; 
 
-        public override string ExceptedCeilingSql => "INSERT INTO destination_entities (double_value) VALUES (CEILING(NEW.double_value));"; 
+        public override string ExceptedCeilingSql => "INSERT INTO destination_entities (\"double_value\") VALUES (CEILING(NEW.double_value));"; 
 
-        public override string ExceptedCosSql => "INSERT INTO destination_entities (double_value) VALUES (COS(NEW.double_value));"; 
+        public override string ExceptedCosSql => "INSERT INTO destination_entities (\"double_value\") VALUES (COS(NEW.double_value));"; 
 
-        public override string ExceptedExpSql => "INSERT INTO destination_entities (double_value) VALUES (EXP(NEW.double_value));"; 
+        public override string ExceptedExpSql => "INSERT INTO destination_entities (\"double_value\") VALUES (EXP(NEW.double_value));"; 
         
-        public override string ExceptedFloorSql => "INSERT INTO destination_entities (double_value) VALUES (FLOOR(NEW.double_value));"; 
+        public override string ExceptedFloorSql => "INSERT INTO destination_entities (\"double_value\") VALUES (FLOOR(NEW.double_value));"; 
     }
 }

--- a/tests/Laraue.EfCoreTriggers.PostgreSqlTests/Unit/PostgreSqlUnitMemberAssignmentTests.cs
+++ b/tests/Laraue.EfCoreTriggers.PostgreSqlTests/Unit/PostgreSqlUnitMemberAssignmentTests.cs
@@ -12,16 +12,16 @@ namespace Laraue.EfCoreTriggers.PostgreSqlTests.Unit
         public PostgreUnitMemberAssignmentTests() : base(new PostgreSqlProvider(new ContextFactory().CreateDbContext().Model))
         {
         }
-        public override string ExceptedEnumValueSql => "INSERT INTO destination_entities (enum_value) VALUES (NEW.enum_value);";
+        public override string ExceptedEnumValueSql => "INSERT INTO destination_entities (\"enum_value\") VALUES (NEW.enum_value);";
 
-        public override string ExceptedDecimalAddSql => "INSERT INTO destination_entities (decimal_value) VALUES (NEW.decimal_value + 3);";
+        public override string ExceptedDecimalAddSql => "INSERT INTO destination_entities (\"decimal_value\") VALUES (NEW.decimal_value + 3);";
 
-        public override string ExceptedDoubleSubSql => "INSERT INTO destination_entities (double_value) VALUES (NEW.double_value + 3);";
+        public override string ExceptedDoubleSubSql => "INSERT INTO destination_entities (\"double_value\") VALUES (NEW.double_value + 3);";
 
-        public override string ExceptedIntMultiplySql => "INSERT INTO destination_entities (int_value) VALUES (NEW.int_value * 2);";
+        public override string ExceptedIntMultiplySql => "INSERT INTO destination_entities (\"int_value\") VALUES (NEW.int_value * 2);";
 
-        public override string ExceptedBooleanSql => "INSERT INTO destination_entities (boolean_value) VALUES (NEW.boolean_value is false);";
+        public override string ExceptedBooleanSql => "INSERT INTO destination_entities (\"boolean_value\") VALUES (NEW.boolean_value is false);";
 
-        public override string ExceptedNewGuidSql => "INSERT INTO destination_entities (guid_value) VALUES (uuid_generate_v4());";
+        public override string ExceptedNewGuidSql => "INSERT INTO destination_entities (\"guid_value\") VALUES (uuid_generate_v4());";
     }
 }

--- a/tests/Laraue.EfCoreTriggers.PostgreSqlTests/Unit/PostgreSqlUnitStringFunctionTests.cs
+++ b/tests/Laraue.EfCoreTriggers.PostgreSqlTests/Unit/PostgreSqlUnitStringFunctionTests.cs
@@ -12,18 +12,18 @@ namespace Laraue.EfCoreTriggers.PostgreSqlTests.Unit
         public PostgreSqlUnitStringFunctionTests() : base(new PostgreSqlProvider(new ContextFactory().CreateDbContext().Model))
         {
         }
-        public override string ExceptedConcatSql => "INSERT INTO destination_entities (string_field) VALUES (CONCAT(NEW.string_field, 'abc'));";
+        public override string ExceptedConcatSql => "INSERT INTO destination_entities (\"string_field\") VALUES (CONCAT(NEW.string_field, 'abc'));";
 
-        public override string ExceptedStringLowerSql => "INSERT INTO destination_entities (string_field) VALUES (LOWER(NEW.string_field));";
+        public override string ExceptedStringLowerSql => "INSERT INTO destination_entities (\"string_field\") VALUES (LOWER(NEW.string_field));";
 
-        public override string ExceptedStringUpperSql => "INSERT INTO destination_entities (string_field) VALUES (UPPER(NEW.string_field));";
+        public override string ExceptedStringUpperSql => "INSERT INTO destination_entities (\"string_field\") VALUES (UPPER(NEW.string_field));";
 
-        public override string ExceptedStringTrimSql => "INSERT INTO destination_entities (string_field) VALUES (BTRIM(NEW.string_field));";
+        public override string ExceptedStringTrimSql => "INSERT INTO destination_entities (\"string_field\") VALUES (BTRIM(NEW.string_field));";
 
-        public override string ExceptedContainsSql => "INSERT INTO destination_entities (boolean_value) VALUES (STRPOS(NEW.string_field, 'abc') > 0);";
+        public override string ExceptedContainsSql => "INSERT INTO destination_entities (\"boolean_value\") VALUES (STRPOS(NEW.string_field, 'abc') > 0);";
 
-        public override string ExceptedEndsWithSql => "INSERT INTO destination_entities (boolean_value) VALUES (NEW.string_field LIKE ('%' || 'abc'));";
+        public override string ExceptedEndsWithSql => "INSERT INTO destination_entities (\"boolean_value\") VALUES (NEW.string_field LIKE ('%' || 'abc'));";
 
-        public override string ExceptedIsNullOrEmptySql => "INSERT INTO destination_entities (boolean_value) VALUES (NEW.string_field IS NULL OR NEW.string_field = '');";
+        public override string ExceptedIsNullOrEmptySql => "INSERT INTO destination_entities (\"boolean_value\") VALUES (NEW.string_field IS NULL OR NEW.string_field = '');";
     }
 }

--- a/tests/Laraue.EfCoreTriggers.SqlLiteTests/Unit/SqlLiteUnitMathFunctionsTests.cs
+++ b/tests/Laraue.EfCoreTriggers.SqlLiteTests/Unit/SqlLiteUnitMathFunctionsTests.cs
@@ -13,23 +13,23 @@ namespace Laraue.EfCoreTriggers.SqlLiteTests.Unit
         {
         }
 
-        public override string ExceptedAbsSql => "INSERT INTO destination_entities (decimal_value) VALUES (ABS(NEW.decimal_value));";
+        public override string ExceptedAbsSql => "INSERT INTO destination_entities (\"decimal_value\") VALUES (ABS(NEW.decimal_value));";
 
-        public override string ExceptedAcosSql => "INSERT INTO destination_entities (double_value) VALUES (ACOS(NEW.double_value));";
+        public override string ExceptedAcosSql => "INSERT INTO destination_entities (\"double_value\") VALUES (ACOS(NEW.double_value));";
 
-        public override string ExceptedAsinSql => "INSERT INTO destination_entities (double_value) VALUES (ASIN(NEW.double_value));";
+        public override string ExceptedAsinSql => "INSERT INTO destination_entities (\"double_value\") VALUES (ASIN(NEW.double_value));";
 
-        public override string ExceptedAtanSql => "INSERT INTO destination_entities (double_value) VALUES (ATAN(NEW.double_value));";
+        public override string ExceptedAtanSql => "INSERT INTO destination_entities (\"double_value\") VALUES (ATAN(NEW.double_value));";
 
-        public override string ExceptedAtan2Sql => "INSERT INTO destination_entities (double_value) VALUES (ATAN2(NEW.double_value, NEW.double_value));";
+        public override string ExceptedAtan2Sql => "INSERT INTO destination_entities (\"double_value\") VALUES (ATAN2(NEW.double_value, NEW.double_value));";
 
-        public override string ExceptedCeilingSql => "INSERT INTO destination_entities (double_value) VALUES (CEIL(NEW.double_value));";
+        public override string ExceptedCeilingSql => "INSERT INTO destination_entities (\"double_value\") VALUES (CEIL(NEW.double_value));";
 
-        public override string ExceptedCosSql => "INSERT INTO destination_entities (double_value) VALUES (COS(NEW.double_value));";
+        public override string ExceptedCosSql => "INSERT INTO destination_entities (\"double_value\") VALUES (COS(NEW.double_value));";
 
-        public override string ExceptedExpSql => "INSERT INTO destination_entities (double_value) VALUES (EXP(NEW.double_value));";
+        public override string ExceptedExpSql => "INSERT INTO destination_entities (\"double_value\") VALUES (EXP(NEW.double_value));";
 
-        public override string ExceptedFloorSql => "INSERT INTO destination_entities (double_value) VALUES (FLOOR(NEW.double_value));";
+        public override string ExceptedFloorSql => "INSERT INTO destination_entities (\"double_value\") VALUES (FLOOR(NEW.double_value));";
 
     }
 }

--- a/tests/Laraue.EfCoreTriggers.SqlLiteTests/Unit/SqlLiteUnitMemberAssignmentTests.cs
+++ b/tests/Laraue.EfCoreTriggers.SqlLiteTests/Unit/SqlLiteUnitMemberAssignmentTests.cs
@@ -13,17 +13,17 @@ namespace Laraue.EfCoreTriggers.SqlLiteTests.Unit
         {
         }
 
-        public override string ExceptedEnumValueSql => "INSERT INTO destination_entities (enum_value) VALUES (NEW.enum_value);";
+        public override string ExceptedEnumValueSql => "INSERT INTO destination_entities (\"enum_value\") VALUES (NEW.enum_value);";
 
-        public override string ExceptedDecimalAddSql => "INSERT INTO destination_entities (decimal_value) VALUES (NEW.decimal_value + 3);";
+        public override string ExceptedDecimalAddSql => "INSERT INTO destination_entities (\"decimal_value\") VALUES (NEW.decimal_value + 3);";
 
-        public override string ExceptedDoubleSubSql => "INSERT INTO destination_entities (double_value) VALUES (NEW.double_value + 3);";
+        public override string ExceptedDoubleSubSql => "INSERT INTO destination_entities (\"double_value\") VALUES (NEW.double_value + 3);";
 
-        public override string ExceptedIntMultiplySql => "INSERT INTO destination_entities (int_value) VALUES (NEW.int_value * 2);";
+        public override string ExceptedIntMultiplySql => "INSERT INTO destination_entities (\"int_value\") VALUES (NEW.int_value * 2);";
 
-        public override string ExceptedBooleanSql => "INSERT INTO destination_entities (boolean_value) VALUES (NEW.boolean_value is false);";
+        public override string ExceptedBooleanSql => "INSERT INTO destination_entities (\"boolean_value\") VALUES (NEW.boolean_value is false);";
 
-        public override string ExceptedNewGuidSql => "INSERT INTO destination_entities (guid_value) VALUES (lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-4' || substr(lower(hex(randomblob(2))),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || substr(lower(hex(randomblob(2))),2) || '-' || lower(hex(randomblob(6))));";
+        public override string ExceptedNewGuidSql => "INSERT INTO destination_entities (\"guid_value\") VALUES (lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-4' || substr(lower(hex(randomblob(2))),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || substr(lower(hex(randomblob(2))),2) || '-' || lower(hex(randomblob(6))));";
 
     }
 }

--- a/tests/Laraue.EfCoreTriggers.SqlLiteTests/Unit/SqlLiteUnitStringFunctionsTests.cs
+++ b/tests/Laraue.EfCoreTriggers.SqlLiteTests/Unit/SqlLiteUnitStringFunctionsTests.cs
@@ -13,19 +13,19 @@ namespace Laraue.EfCoreTriggers.SqlLiteTests.Unit
         {
         }
 
-        public override string ExceptedConcatSql => "INSERT INTO destination_entities (string_field) VALUES (NEW.string_field || 'abc');";
+        public override string ExceptedConcatSql => "INSERT INTO destination_entities (\"string_field\") VALUES (NEW.string_field || 'abc');";
 
-        public override string ExceptedStringLowerSql => "INSERT INTO destination_entities (string_field) VALUES (LOWER(NEW.string_field));";
+        public override string ExceptedStringLowerSql => "INSERT INTO destination_entities (\"string_field\") VALUES (LOWER(NEW.string_field));";
 
-        public override string ExceptedStringUpperSql => "INSERT INTO destination_entities (string_field) VALUES (UPPER(NEW.string_field));";
+        public override string ExceptedStringUpperSql => "INSERT INTO destination_entities (\"string_field\") VALUES (UPPER(NEW.string_field));";
 
-        public override string ExceptedStringTrimSql => "INSERT INTO destination_entities (string_field) VALUES (TRIM(NEW.string_field));";
+        public override string ExceptedStringTrimSql => "INSERT INTO destination_entities (\"string_field\") VALUES (TRIM(NEW.string_field));";
 
-        public override string ExceptedContainsSql => "INSERT INTO destination_entities (boolean_value) VALUES (INSTR(NEW.string_field, 'abc') > 0);";
+        public override string ExceptedContainsSql => "INSERT INTO destination_entities (\"boolean_value\") VALUES (INSTR(NEW.string_field, 'abc') > 0);";
 
-        public override string ExceptedEndsWithSql => "INSERT INTO destination_entities (boolean_value) VALUES (NEW.string_field LIKE ('%' || 'abc'));";
+        public override string ExceptedEndsWithSql => "INSERT INTO destination_entities (\"boolean_value\") VALUES (NEW.string_field LIKE ('%' || 'abc'));";
 
-        public override string ExceptedIsNullOrEmptySql => "INSERT INTO destination_entities (boolean_value) VALUES (NEW.string_field IS NULL OR NEW.string_field = '');";
+        public override string ExceptedIsNullOrEmptySql => "INSERT INTO destination_entities (\"boolean_value\") VALUES (NEW.string_field IS NULL OR NEW.string_field = '');";
 
 
     }

--- a/tests/Laraue.EfCoreTriggers.SqlServerTests/Unit/SqlServerUnitMathFunctionsTest.cs
+++ b/tests/Laraue.EfCoreTriggers.SqlServerTests/Unit/SqlServerUnitMathFunctionsTest.cs
@@ -12,23 +12,23 @@ namespace Laraue.EfCoreTriggers.SqlServerTests.Unit
         public SqlServerUnitMathFunctionsTest() : base(new SqlServerProvider(new ContextFactory().CreateDbContext().Model))
         {
         }
-        public override string ExceptedAbsSql => "INSERT INTO destination_entities (decimal_value) VALUES (ABS(@NewDecimalValue));";
+        public override string ExceptedAbsSql => "INSERT INTO destination_entities (\"decimal_value\") VALUES (ABS(@NewDecimalValue));";
 
-        public override string ExceptedAcosSql => "INSERT INTO destination_entities (double_value) VALUES (ACOS(@NewDoubleValue));";
+        public override string ExceptedAcosSql => "INSERT INTO destination_entities (\"double_value\") VALUES (ACOS(@NewDoubleValue));";
 
-        public override string ExceptedAsinSql => "INSERT INTO destination_entities (double_value) VALUES (ASIN(@NewDoubleValue));";
+        public override string ExceptedAsinSql => "INSERT INTO destination_entities (\"double_value\") VALUES (ASIN(@NewDoubleValue));";
 
-        public override string ExceptedAtanSql => "INSERT INTO destination_entities (double_value) VALUES (ATAN(@NewDoubleValue));";
+        public override string ExceptedAtanSql => "INSERT INTO destination_entities (\"double_value\") VALUES (ATAN(@NewDoubleValue));";
 
-        public override string ExceptedAtan2Sql => "INSERT INTO destination_entities (double_value) VALUES (ATN2(@NewDoubleValue, @NewDoubleValue));";
+        public override string ExceptedAtan2Sql => "INSERT INTO destination_entities (\"double_value\") VALUES (ATN2(@NewDoubleValue, @NewDoubleValue));";
 
-        public override string ExceptedCeilingSql => "INSERT INTO destination_entities (double_value) VALUES (CEILING(@NewDoubleValue));";
+        public override string ExceptedCeilingSql => "INSERT INTO destination_entities (\"double_value\") VALUES (CEILING(@NewDoubleValue));";
 
-        public override string ExceptedCosSql => "INSERT INTO destination_entities (double_value) VALUES (COS(@NewDoubleValue));";
+        public override string ExceptedCosSql => "INSERT INTO destination_entities (\"double_value\") VALUES (COS(@NewDoubleValue));";
 
-        public override string ExceptedExpSql => "INSERT INTO destination_entities (double_value) VALUES (EXP(@NewDoubleValue));";
+        public override string ExceptedExpSql => "INSERT INTO destination_entities (\"double_value\") VALUES (EXP(@NewDoubleValue));";
 
-        public override string ExceptedFloorSql => "INSERT INTO destination_entities (double_value) VALUES (FLOOR(@NewDoubleValue));";
+        public override string ExceptedFloorSql => "INSERT INTO destination_entities (\"double_value\") VALUES (FLOOR(@NewDoubleValue));";
 
     }
 }

--- a/tests/Laraue.EfCoreTriggers.SqlServerTests/Unit/SqlServerUnitMemberAssignmentTests.cs
+++ b/tests/Laraue.EfCoreTriggers.SqlServerTests/Unit/SqlServerUnitMemberAssignmentTests.cs
@@ -12,17 +12,17 @@ namespace Laraue.EfCoreTriggers.SqlServerTests.Unit
         public SqlServerUnitMemberAssignmentTests() : base(new SqlServerProvider(new ContextFactory().CreateDbContext().Model))
         {
         }
-        public override string ExceptedEnumValueSql => "INSERT INTO destination_entities (enum_value) VALUES (@NewEnumValue);";
+        public override string ExceptedEnumValueSql => "INSERT INTO destination_entities (\"enum_value\") VALUES (@NewEnumValue);";
 
-        public override string ExceptedDecimalAddSql => "INSERT INTO destination_entities (decimal_value) VALUES (@NewDecimalValue + 3);";
+        public override string ExceptedDecimalAddSql => "INSERT INTO destination_entities (\"decimal_value\") VALUES (@NewDecimalValue + 3);";
 
-        public override string ExceptedDoubleSubSql => "INSERT INTO destination_entities (double_value) VALUES (@NewDoubleValue + 3);";
+        public override string ExceptedDoubleSubSql => "INSERT INTO destination_entities (\"double_value\") VALUES (@NewDoubleValue + 3);";
 
-        public override string ExceptedIntMultiplySql => "INSERT INTO destination_entities (int_value) VALUES (@NewIntValue * 2);";
+        public override string ExceptedIntMultiplySql => "INSERT INTO destination_entities (\"int_value\") VALUES (@NewIntValue * 2);";
 
-        public override string ExceptedBooleanSql => "INSERT INTO destination_entities (boolean_value) VALUES (CASE WHEN @NewBooleanValue = 0 THEN 1 ELSE 0 END);";
+        public override string ExceptedBooleanSql => "INSERT INTO destination_entities (\"boolean_value\") VALUES (CASE WHEN @NewBooleanValue = 0 THEN 1 ELSE 0 END);";
 
-        public override string ExceptedNewGuidSql => "INSERT INTO destination_entities (guid_value) VALUES (NEWID());";
+        public override string ExceptedNewGuidSql => "INSERT INTO destination_entities (\"guid_value\") VALUES (NEWID());";
 
        
         

--- a/tests/Laraue.EfCoreTriggers.SqlServerTests/Unit/SqlServerUnitStringFunctionsTests.cs
+++ b/tests/Laraue.EfCoreTriggers.SqlServerTests/Unit/SqlServerUnitStringFunctionsTests.cs
@@ -12,19 +12,19 @@ namespace Laraue.EfCoreTriggers.SqlServerTests.Unit
         public SqlServerUnitStringFunctionsTests() : base(new SqlServerProvider(new ContextFactory().CreateDbContext().Model))
         {
         }
-        public override string ExceptedConcatSql => "INSERT INTO destination_entities (string_field) VALUES (@NewStringField + 'abc');";
+        public override string ExceptedConcatSql => "INSERT INTO destination_entities (\"string_field\") VALUES (@NewStringField + 'abc');";
 
-        public override string ExceptedStringLowerSql => "INSERT INTO destination_entities (string_field) VALUES (LOWER(@NewStringField));";
+        public override string ExceptedStringLowerSql => "INSERT INTO destination_entities (\"string_field\") VALUES (LOWER(@NewStringField));";
 
-        public override string ExceptedStringUpperSql => "INSERT INTO destination_entities (string_field) VALUES (UPPER(@NewStringField));";
+        public override string ExceptedStringUpperSql => "INSERT INTO destination_entities (\"string_field\") VALUES (UPPER(@NewStringField));";
 
-        public override string ExceptedStringTrimSql => "INSERT INTO destination_entities (string_field) VALUES (LTRIM(RTRIM(@NewStringField)));";
+        public override string ExceptedStringTrimSql => "INSERT INTO destination_entities (\"string_field\") VALUES (LTRIM(RTRIM(@NewStringField)));";
 
-        public override string ExceptedContainsSql => "INSERT INTO destination_entities (boolean_value) VALUES (CASE WHEN CHARINDEX('abc', @NewStringField) > 0 THEN 1 ELSE 0 END);";
+        public override string ExceptedContainsSql => "INSERT INTO destination_entities (\"boolean_value\") VALUES (CASE WHEN CHARINDEX('abc', @NewStringField) > 0 THEN 1 ELSE 0 END);";
 
-        public override string ExceptedEndsWithSql => "INSERT INTO destination_entities (boolean_value) VALUES (CASE WHEN @NewStringField LIKE ('%' + 'abc') THEN 1 ELSE 0 END);";
+        public override string ExceptedEndsWithSql => "INSERT INTO destination_entities (\"boolean_value\") VALUES (CASE WHEN @NewStringField LIKE ('%' + 'abc') THEN 1 ELSE 0 END);";
 
-        public override string ExceptedIsNullOrEmptySql => "INSERT INTO destination_entities (boolean_value) VALUES (CASE WHEN @NewStringField IS NULL OR @NewStringField = '' THEN 1 ELSE 0 END);";
+        public override string ExceptedIsNullOrEmptySql => "INSERT INTO destination_entities (\"boolean_value\") VALUES (CASE WHEN @NewStringField IS NULL OR @NewStringField = '' THEN 1 ELSE 0 END);";
 
     }
 }


### PR DESCRIPTION
EF Core supports using database keywords as entity property name. So I think it's better that EfCoreTriggers also supports that.