### PR TITLE
remove quotes from postgres tablename

### DIFF
--- a/src/Laraue.EfCoreTriggers.PostgreSql/PostgreSqlTriggerVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.PostgreSql/PostgreSqlTriggerVisitor.cs
@@ -48,7 +48,7 @@ public class PostgreSqlTriggerVisitor : BaseTriggerVisitor
             .AppendNewLine("END;")
             .AppendNewLine($"${trigger.Name}$ LANGUAGE plpgsql;")
             .AppendNewLine($"CREATE TRIGGER {trigger.Name} {GetTriggerTimeName(trigger.TriggerTime)} {trigger.TriggerEvent.ToString().ToUpper()}")
-            .AppendNewLine($"ON \"{_adapter.GetTableName(trigger.TriggerEntityType)}\"")
+            .AppendNewLine($"ON {_adapter.GetTableName(trigger.TriggerEntityType)}")
             .AppendNewLine($"FOR EACH ROW EXECUTE PROCEDURE {trigger.Name}();");
         
         return sql;


### PR DESCRIPTION
# Bug description:

When executing acreated migration, containing insertAfter, deleteAfter, updateAfter trigger, against a postgres database, the migration fails because the table can't be found.

# Fix:

- Removed quotes from Postgres 

