### PR TITLE
use table schema for function creation

### DIFF
--- a/src/Laraue.EfCoreTriggers.Common/Services/IDbSchemaRetriever.cs
+++ b/src/Laraue.EfCoreTriggers.Common/Services/IDbSchemaRetriever.cs
@@ -24,6 +24,14 @@ public interface IDbSchemaRetriever
     string GetTableName(Type entity);
 
     /// <summary>
+    /// Get the function name with the entities schema.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <param name="name"></param>
+    /// <returns></returns>
+    string GetFunctionName(Type entity, string name);
+
+    /// <summary>
     /// Get all members which are used in primary key.
     /// </summary>
     /// <param name="type"></param>

--- a/src/Laraue.EfCoreTriggers.Common/Services/Impl/EfCoreDbSchemaRetriever.cs
+++ b/src/Laraue.EfCoreTriggers.Common/Services/Impl/EfCoreDbSchemaRetriever.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Laraue.EfCoreTriggers.Common.Services.Impl;
 
@@ -86,6 +85,22 @@ public class EfCoreDbSchemaRetriever : IDbSchemaRetriever
             : $"{schemaName}.{tableName}";
     }
     
+    /// <inheritdoc />
+    public string GetFunctionName(Type entity, string name)
+    {
+        if (!TableNamesCache.ContainsKey(entity))
+        {
+            var entityType = Model.FindEntityType(entity);
+            TableNamesCache.Add(entity, entityType.GetTableName());
+        }
+
+        var schemaName = GetTableSchemaName(entity);
+
+        return string.IsNullOrWhiteSpace(schemaName)
+            ? name
+            : $"{schemaName}.{name}";
+    }
+
     /// <summary>
     /// Get schema name for passed <see cref="Type">ClrType</see>.
     /// </summary>

--- a/src/Laraue.EfCoreTriggers.Common/Services/Impl/ExpressionVisitors/NewExpressionVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.Common/Services/Impl/ExpressionVisitors/NewExpressionVisitor.cs
@@ -15,6 +15,10 @@ public abstract class NewExpressionVisitor : BaseExpressionVisitor<NewExpression
         {
             return GetNewGuidSql();
         }
+        if (expression.Type == typeof(DateTimeOffset))
+        {
+            return GetNewDateTimeOffsetSql();
+        }
         
         throw new System.NotImplementedException();
     }
@@ -24,4 +28,10 @@ public abstract class NewExpressionVisitor : BaseExpressionVisitor<NewExpression
     /// </summary>
     /// <returns></returns>
     protected abstract SqlBuilder GetNewGuidSql();
+    
+    /// <summary>
+    /// Generate new DateTimeOffset SQL.
+    /// </summary>
+    /// <returns></returns>
+    protected abstract SqlBuilder GetNewDateTimeOffsetSql();
 }

--- a/src/Laraue.EfCoreTriggers.MySql/MySqlNewExpressionVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.MySql/MySqlNewExpressionVisitor.cs
@@ -9,4 +9,10 @@ public class MySqlNewExpressionVisitor : NewExpressionVisitor
     {
         return SqlBuilder.FromString("UUID()");
     }
+
+    /// <inheritdoc />
+    protected override SqlBuilder GetNewDateTimeOffsetSql()
+    {
+        return SqlBuilder.FromString("CURRENT_DATE()");
+    }
 }

--- a/src/Laraue.EfCoreTriggers.PostgreSql/PostgreSqlTriggerVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.PostgreSql/PostgreSqlTriggerVisitor.cs
@@ -23,7 +23,7 @@ public class PostgreSqlTriggerVisitor : BaseTriggerVisitor
             .Select(action => _factory.Visit(action, new VisitedMembers()))
             .ToArray();
 
-        var sql = SqlBuilder.FromString($"CREATE FUNCTION {trigger.Name}() RETURNS trigger as ${trigger.Name}$")
+        var sql = SqlBuilder.FromString($"CREATE FUNCTION {_adapter.GetFunctionName(trigger.TriggerEntityType, trigger.Name)}() RETURNS trigger as ${trigger.Name}$")
             .AppendNewLine("BEGIN")
             .WithIdent(triggerSql =>
             {
@@ -49,7 +49,7 @@ public class PostgreSqlTriggerVisitor : BaseTriggerVisitor
             .AppendNewLine($"${trigger.Name}$ LANGUAGE plpgsql;")
             .AppendNewLine($"CREATE TRIGGER {trigger.Name} {GetTriggerTimeName(trigger.TriggerTime)} {trigger.TriggerEvent.ToString().ToUpper()}")
             .AppendNewLine($"ON {_adapter.GetTableName(trigger.TriggerEntityType)}")
-            .AppendNewLine($"FOR EACH ROW EXECUTE PROCEDURE {trigger.Name}();");
+            .AppendNewLine($"FOR EACH ROW EXECUTE PROCEDURE {_adapter.GetFunctionName(trigger.TriggerEntityType, trigger.Name)}();");
         
         return sql;
     }

--- a/src/Laraue.EfCoreTriggers.PostgreSql/PostreSqlNewExpressionVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.PostgreSql/PostreSqlNewExpressionVisitor.cs
@@ -7,6 +7,12 @@ public class PostreSqlNewExpressionVisitor : NewExpressionVisitor
 {
     protected override SqlBuilder GetNewGuidSql()
     {
-        return SqlBuilder.FromString("uuid_generate_v4()");
+        return SqlBuilder.FromString("gen_random_uuid()");
+    }
+
+    /// <inheritdoc />
+    protected override SqlBuilder GetNewDateTimeOffsetSql()
+    {
+        return SqlBuilder.FromString("CURRENT_DATE");
     }
 }

--- a/src/Laraue.EfCoreTriggers.SqlLite/SqliteNewExpressionVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.SqlLite/SqliteNewExpressionVisitor.cs
@@ -12,4 +12,10 @@ public class SqliteNewExpressionVisitor : NewExpressionVisitor
             "substr(lower(hex(randomblob(2))),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || " +
             "substr(lower(hex(randomblob(2))),2) || '-' || lower(hex(randomblob(6)))");
     }
+
+    /// <inheritdoc />
+    protected override SqlBuilder GetNewDateTimeOffsetSql()
+    {
+        return SqlBuilder.FromString("DATE(‘now’)");
+    }
 }

--- a/src/Laraue.EfCoreTriggers.SqlServer/SqlServerNewExpressionVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.SqlServer/SqlServerNewExpressionVisitor.cs
@@ -9,4 +9,10 @@ public class SqlServerNewExpressionVisitor : NewExpressionVisitor
     {
         return SqlBuilder.FromString("NEWID()");
     }
+
+    /// <inheritdoc />
+    protected override SqlBuilder GetNewDateTimeOffsetSql()
+    {
+        return SqlBuilder.FromString("CURRENT_DATE");
+    }
 }


### PR DESCRIPTION
# Issues

- Couldn't use DateTimeOffset in the convention based configuration
- All Functions were created in the public namespace

# Implemented Changes:

- Added DateTimeOffset Type in the NewExpressionVisitor
- Functions are prefixed by the tables schema if existing.