### PR TITLE
fix drop trigger

### DIFF
--- a/src/Laraue.EfCoreTriggers.Common/Migrations/MigrationsModelDiffer.cs
+++ b/src/Laraue.EfCoreTriggers.Common/Migrations/MigrationsModelDiffer.cs
@@ -60,7 +60,7 @@ namespace Laraue.EfCoreTriggers.Common.Migrations
 
                 foreach (var annotation in deletedEntityType.GetTriggerAnnotations())
                 {
-                    _triggerVisitor.AddDeleteTriggerSqlMigration(deleteTriggerOperations, annotation, sourceModel);
+                    _triggerVisitor.AddDeleteTriggerSqlMigration(deleteTriggerOperations, annotation, deletedEntityType);
                 }
             }
 
@@ -106,7 +106,7 @@ namespace Laraue.EfCoreTriggers.Common.Migrations
                         continue;
                     }
                     
-                    _triggerVisitor.AddDeleteTriggerSqlMigration(deleteTriggerOperations, oldValue, sourceModel);
+                    _triggerVisitor.AddDeleteTriggerSqlMigration(deleteTriggerOperations, oldValue, sourceModel?.FindEntityType(entityTypeName));
                     createTriggerOperations.AddCreateTriggerSqlMigration(newValue);
                 }
 
@@ -115,7 +115,7 @@ namespace Laraue.EfCoreTriggers.Common.Migrations
                 {
                     var oldTriggerAnnotation = oldEntityType?.GetAnnotation(oldTriggerName);
 
-                    _triggerVisitor.AddDeleteTriggerSqlMigration(deleteTriggerOperations, oldTriggerAnnotation, sourceModel);
+                    _triggerVisitor.AddDeleteTriggerSqlMigration(deleteTriggerOperations, oldTriggerAnnotation, oldEntityType);
                 }
 
                 // If trigger was added, create it.
@@ -247,13 +247,13 @@ namespace Laraue.EfCoreTriggers.Common.Migrations
         /// <param name="triggerVisitor"></param>
         /// <param name="list"></param>
         /// <param name="annotation"></param>
-        /// <param name="model"></param>
+        /// <param name="entityType"></param>
         /// <returns></returns>
-        public static IList<SqlOperation> AddDeleteTriggerSqlMigration(this ITriggerVisitor triggerVisitor, IList<SqlOperation> list, IAnnotation annotation, IModel model)
+        public static IList<SqlOperation> AddDeleteTriggerSqlMigration(this ITriggerVisitor triggerVisitor, IList<SqlOperation> list, IAnnotation annotation, IEntityType entityType)
         {
             list.Add(new SqlOperation
             {
-                Sql = triggerVisitor.GenerateDeleteTriggerSql(annotation.Name),
+                Sql = triggerVisitor.GenerateDeleteTriggerSql(annotation.Name, entityType),
             });
             
             return list;

--- a/src/Laraue.EfCoreTriggers.Common/Services/Impl/TriggerVisitors/BaseTriggerVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.Common/Services/Impl/TriggerVisitors/BaseTriggerVisitor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Laraue.EfCoreTriggers.Common.TriggerBuilders;
 using Laraue.EfCoreTriggers.Common.TriggerBuilders.Base;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Laraue.EfCoreTriggers.Common.Services.Impl.TriggerVisitors;
 
@@ -50,5 +51,5 @@ public abstract class BaseTriggerVisitor : ITriggerVisitor
     public abstract string GenerateCreateTriggerSql(ITrigger trigger);
 
     /// <inheritdoc />
-    public abstract string GenerateDeleteTriggerSql(string triggerName);
+    public abstract string GenerateDeleteTriggerSql(string triggerName, IEntityType entityType);
 }

--- a/src/Laraue.EfCoreTriggers.Common/Services/Impl/TriggerVisitors/ITriggerVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.Common/Services/Impl/TriggerVisitors/ITriggerVisitor.cs
@@ -1,4 +1,5 @@
 ﻿using Laraue.EfCoreTriggers.Common.TriggerBuilders.Base;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Laraue.EfCoreTriggers.Common.Services.Impl.TriggerVisitors;
 
@@ -13,11 +14,12 @@ public interface ITriggerVisitor
     /// <param name="trigger"></param>
     /// <returns></returns>
     string GenerateCreateTriggerSql(ITrigger trigger);
-    
+
     /// <summary>
     /// Generates drop trigger SQL.
     /// </summary>
     /// <param name="triggerName"></param>
+    /// <param name="entityType"></param>
     /// <returns></returns>
-    string GenerateDeleteTriggerSql(string triggerName);
+    string GenerateDeleteTriggerSql(string triggerName, IEntityType entityType);
 }

--- a/src/Laraue.EfCoreTriggers.MySql/MySqlTriggerVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.MySql/MySqlTriggerVisitor.cs
@@ -3,6 +3,7 @@ using Laraue.EfCoreTriggers.Common.Services;
 using Laraue.EfCoreTriggers.Common.Services.Impl.TriggerVisitors;
 using Laraue.EfCoreTriggers.Common.SqlGeneration;
 using Laraue.EfCoreTriggers.Common.TriggerBuilders.Base;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Laraue.EfCoreTriggers.MySql;
 
@@ -55,7 +56,7 @@ public class MySqlTriggerVisitor : BaseTriggerVisitor
         return sql;
     }
 
-    public override string GenerateDeleteTriggerSql(string triggerName)
+    public override string GenerateDeleteTriggerSql(string triggerName, IEntityType entityType)
     {
         return SqlBuilder.FromString($"DROP TRIGGER {triggerName};");
     }

--- a/src/Laraue.EfCoreTriggers.PostgreSql/PostgreSqlTriggerVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.PostgreSql/PostgreSqlTriggerVisitor.cs
@@ -3,6 +3,8 @@ using Laraue.EfCoreTriggers.Common.Services;
 using Laraue.EfCoreTriggers.Common.Services.Impl.TriggerVisitors;
 using Laraue.EfCoreTriggers.Common.SqlGeneration;
 using Laraue.EfCoreTriggers.Common.TriggerBuilders.Base;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Laraue.EfCoreTriggers.PostgreSql;
 
@@ -54,8 +56,12 @@ public class PostgreSqlTriggerVisitor : BaseTriggerVisitor
         return sql;
     }
 
-    public override string GenerateDeleteTriggerSql(string triggerName)
+    public override string GenerateDeleteTriggerSql(string triggerName, IEntityType entityType)
     {
-        return SqlBuilder.FromString($"DROP FUNCTION {triggerName}() CASCADE;");
+        var schemaName = entityType.GetSchema();
+        var name = string.IsNullOrWhiteSpace(schemaName)
+            ? triggerName
+            : $"{schemaName}.{triggerName}";
+        return SqlBuilder.FromString($"DROP FUNCTION {name}() CASCADE;");
     }
 }

--- a/src/Laraue.EfCoreTriggers.SqlLite/SqliteTriggerVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.SqlLite/SqliteTriggerVisitor.cs
@@ -3,6 +3,7 @@ using Laraue.EfCoreTriggers.Common.Services;
 using Laraue.EfCoreTriggers.Common.Services.Impl.TriggerVisitors;
 using Laraue.EfCoreTriggers.Common.SqlGeneration;
 using Laraue.EfCoreTriggers.Common.TriggerBuilders.Base;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Laraue.EfCoreTriggers.SqlLite;
 
@@ -61,7 +62,7 @@ public class SqliteTriggerVisitor : BaseTriggerVisitor
         return sql;
     }
 
-    public override string GenerateDeleteTriggerSql(string triggerName)
+    public override string GenerateDeleteTriggerSql(string triggerName, IEntityType entityType)
     {
         return SqlBuilder.FromString("PRAGMA writable_schema = 1; ")
             .AppendNewLine($"DELETE FROM sqlite_master WHERE type = 'trigger' AND name like '{triggerName}%';")

--- a/src/Laraue.EfCoreTriggers.SqlServer/SqlServerTriggerVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.SqlServer/SqlServerTriggerVisitor.cs
@@ -7,6 +7,7 @@ using Laraue.EfCoreTriggers.Common.Services.Impl.TriggerVisitors;
 using Laraue.EfCoreTriggers.Common.SqlGeneration;
 using Laraue.EfCoreTriggers.Common.TriggerBuilders;
 using Laraue.EfCoreTriggers.Common.TriggerBuilders.Base;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Laraue.EfCoreTriggers.SqlServer;
 
@@ -208,7 +209,7 @@ public class SqlServerTriggerVisitor : BaseTriggerVisitor
         return $"DECLARE {cursorName} CURSOR FOR";
     }
 
-    public override string GenerateDeleteTriggerSql(string triggerName)
+    public override string GenerateDeleteTriggerSql(string triggerName, IEntityType entityType)
     {
         return $"DROP TRIGGER {triggerName};";
     }


### PR DESCRIPTION
## Problem ##

When creating the migration the drop Trigger for Postgres usage didn't have the Schema in it.

## Solution ##

With this PR the drop trigger will have the schema name of the given entity.