### PR TITLE
Remove JetBrains.Annotations Package

### DIFF
--- a/src/Laraue.EfCoreTriggers.Common/Laraue.EfCoreTriggers.Common.csproj
+++ b/src/Laraue.EfCoreTriggers.Common/Laraue.EfCoreTriggers.Common.csproj
@@ -28,9 +28,5 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.2" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
** Problem **

When commiting code to the Eclipse Foundation it's needed that code from 3rd party resources provide at least a tag with the source to a specific version, even better would be a release. Since JetBrains.Annotations doesn't provide that information I removed the package. It wasn't currently used anyway in my opinion.

** Follow up **

I've created an Issue #61 to implement the explicit Nullable feature from C#, that could've been one reason to use the JetBrains Package.

Would love to handle that, so if you'd like to assign the issue to me.