### PR TITLE
fix: convert dateTimeOffset to current_timestamp

### DIFF
--- a/src/Laraue.EfCoreTriggers.PostgreSql/PostreSqlNewExpressionVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.PostgreSql/PostreSqlNewExpressionVisitor.cs
@@ -13,6 +13,6 @@ public class PostreSqlNewExpressionVisitor : NewExpressionVisitor
     /// <inheritdoc />
     protected override SqlBuilder GetNewDateTimeOffsetSql()
     {
-        return SqlBuilder.FromString("CURRENT_DATE");
+        return SqlBuilder.FromString("CURRENT_TIMESTAMP");
     }
 }

--- a/tests/Laraue.EfCoreTriggers.PostgreSqlTests/Unit/PostgreSqlUnitMemberAssignmentTests.cs
+++ b/tests/Laraue.EfCoreTriggers.PostgreSqlTests/Unit/PostgreSqlUnitMemberAssignmentTests.cs
@@ -32,6 +32,6 @@ namespace Laraue.EfCoreTriggers.PostgreSqlTests.Unit
         
         public override string ExceptedCharValueSql => "INSERT INTO \"destination_entities\" (\"char_value\") SELECT 'a';";
        
-        public override string ExceptedNewDateTimeOffsetSql => "INSERT INTO \"destination_entities\" (\"date_time_offset_value\") SELECT CURRENT_DATE;";
+        public override string ExceptedNewDateTimeOffsetSql => "INSERT INTO \"destination_entities\" (\"date_time_offset_value\") SELECT CURRENT_TIMESTAMP;";
     }
 }


### PR DESCRIPTION
DateTimeoffset is currently coverted to Current_Date and it only stores date not with time, so I changed it to Current_TimeStamp
now it will store both Date and Time