### PR TITLE
DateTime precision increase for SQL Server

### DIFF
--- a/src/Laraue.EfCoreTriggers.SqlServer/Converters/MemberAccess/DateTime/NowVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.SqlServer/Converters/MemberAccess/DateTime/NowVisitor.cs
@@ -17,7 +17,7 @@ namespace Laraue.EfCoreTriggers.SqlServer.Converters.MemberAccess.DateTime
         /// <inheritdoc />
         public override SqlBuilder Visit(MemberExpression expression)
         {
-            return SqlBuilder.FromString("GETDATE()");
+            return SqlBuilder.FromString("SYSDATETIME()");
         }
     }
 }

--- a/src/Laraue.EfCoreTriggers.SqlServer/Converters/MemberAccess/DateTime/UtcNowVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.SqlServer/Converters/MemberAccess/DateTime/UtcNowVisitor.cs
@@ -17,7 +17,7 @@ namespace Laraue.EfCoreTriggers.SqlServer.Converters.MemberAccess.DateTime
         /// <inheritdoc />
         public override SqlBuilder Visit(MemberExpression expression)
         {
-            return SqlBuilder.FromString("GETUTCDATE()");
+            return SqlBuilder.FromString("SYSUTCDATETIME()");
         }
     }
 }

--- a/src/Laraue.EfCoreTriggers.SqlServer/SqlServerNewExpressionVisitor.cs
+++ b/src/Laraue.EfCoreTriggers.SqlServer/SqlServerNewExpressionVisitor.cs
@@ -13,6 +13,6 @@ public class SqlServerNewExpressionVisitor : NewExpressionVisitor
     /// <inheritdoc />
     protected override SqlBuilder GetNewDateTimeOffsetSql()
     {
-        return SqlBuilder.FromString("GETDATE()");
+        return SqlBuilder.FromString("SYSDATETIME()");
     }
 }

--- a/tests/Laraue.EfCoreTriggers.SqlServerTests/Unit/SqlServerUnitDateTimeFunctionsTests.cs
+++ b/tests/Laraue.EfCoreTriggers.SqlServerTests/Unit/SqlServerUnitDateTimeFunctionsTests.cs
@@ -14,8 +14,8 @@ public class SqlServerUnitDateTimeFunctionsTests : UnitDateTimeFunctionsTests
     }
 
     protected override string ExceptedDateTimeUtcNowSql
-        => "INSERT INTO \"destination_entities\" (\"date_time_value\") SELECT GETUTCDATE();";
+        => "INSERT INTO \"destination_entities\" (\"date_time_value\") SELECT SYSUTCDATETIME();";
     
     protected override string ExceptedDateTimeNowSql
-        => "INSERT INTO \"destination_entities\" (\"date_time_value\") SELECT GETDATE();";
+        => "INSERT INTO \"destination_entities\" (\"date_time_value\") SELECT SYSDATETIME();";
 }

--- a/tests/Laraue.EfCoreTriggers.SqlServerTests/Unit/SqlServerUnitMemberAssignmentTests.cs
+++ b/tests/Laraue.EfCoreTriggers.SqlServerTests/Unit/SqlServerUnitMemberAssignmentTests.cs
@@ -32,6 +32,6 @@ namespace Laraue.EfCoreTriggers.SqlServerTests.Unit
 
         public override string ExceptedCharValueSql => "INSERT INTO \"destination_entities\" (\"char_value\") SELECT 'a';";
         
-        public override string ExceptedNewDateTimeOffsetSql => "INSERT INTO \"destination_entities\" (\"date_time_offset_value\") SELECT GETDATE();";
+        public override string ExceptedNewDateTimeOffsetSql => "INSERT INTO \"destination_entities\" (\"date_time_offset_value\") SELECT SYSDATETIME();";
     }
 }


### PR DESCRIPTION
Use `SYSUTCDATETIME` and `SYSDATETIME` instead of `GETUTCDATE` and `GETDATE` respectively.