### PR TITLE
feat: add .net9 support and update to new MigrationsModelDiffer

### DIFF
--- a/src/Laraue.EfCoreTriggers.Common/Laraue.EfCoreTriggers.Common.csproj
+++ b/src/Laraue.EfCoreTriggers.Common/Laraue.EfCoreTriggers.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net8.0;net9.0</TargetFrameworks>
     <Description>Common classes EfCoreTriggers packages.</Description>
     <RepositoryUrl>https://github.com/win7user10/Laraue.EfCoreTriggers</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -36,6 +36,14 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Laraue.EfCoreTriggers.Common/Migrations/MigrationsModelDiffer.cs
+++ b/src/Laraue.EfCoreTriggers.Common/Migrations/MigrationsModelDiffer.cs
@@ -23,7 +23,19 @@ namespace Laraue.EfCoreTriggers.Common.Migrations
         /// <param name="updateAdapterFactory"></param>
         /// <param name="triggerModelDiffer"></param>
         /// <param name="commandBatchPreparerDependencies"></param>
-#if NET6_0_OR_GREATER
+#if NET9_0_OR_GREATER
+        public MigrationsModelDiffer(
+            IRelationalTypeMappingSource typeMappingSource,
+            IMigrationsAnnotationProvider migrationsAnnotationProvider,
+            IRelationalAnnotationProvider relationalAnnotationProvider,
+            IRowIdentityMapFactory rowIdentityMapFactory,
+            CommandBatchPreparerDependencies commandBatchPreparerDependencies,
+            ITriggerModelDiffer triggerModelDiffer) 
+            : base(typeMappingSource, migrationsAnnotationProvider, relationalAnnotationProvider, rowIdentityMapFactory, commandBatchPreparerDependencies)
+        {
+            _triggerModelDiffer = triggerModelDiffer;
+        }
+#elif NET6_0_OR_GREATER
         public MigrationsModelDiffer(
             IRelationalTypeMappingSource typeMappingSource,
             IMigrationsAnnotationProvider migrationsAnnotationProvider,

--- a/src/Laraue.EfCoreTriggers.MySql/Laraue.EfCoreTriggers.MySql.csproj
+++ b/src/Laraue.EfCoreTriggers.MySql/Laraue.EfCoreTriggers.MySql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net8.0;net9.0</TargetFrameworks>
     <Description>Generating native MySql triggers through migrations using EFCore entity builder.</Description>
     <RepositoryUrl>https://github.com/win7user10/Laraue.EfCoreTriggers</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/Laraue.EfCoreTriggers.PostgreSql/Laraue.EfCoreTriggers.PostgreSql.csproj
+++ b/src/Laraue.EfCoreTriggers.PostgreSql/Laraue.EfCoreTriggers.PostgreSql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net8.0;net9.0</TargetFrameworks>
     <Description>Generating native PostgreSql triggers through migrations using EFCore entity builder.</Description>
     <RepositoryUrl>https://github.com/win7user10/Laraue.EfCoreTriggers</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/Laraue.EfCoreTriggers.SqlLite/Laraue.EfCoreTriggers.SqlLite.csproj
+++ b/src/Laraue.EfCoreTriggers.SqlLite/Laraue.EfCoreTriggers.SqlLite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net8.0;net9.0</TargetFrameworks>
     <Description>Generating native SqlLite triggers through migrations using EFCore entity builder.</Description>
     <RepositoryUrl>https://github.com/win7user10/Laraue.EfCoreTriggers</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/Laraue.EfCoreTriggers.SqlServer/Laraue.EfCoreTriggers.SqlServer.csproj
+++ b/src/Laraue.EfCoreTriggers.SqlServer/Laraue.EfCoreTriggers.SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net8.0;net9.0</TargetFrameworks>
     <Description>Generating native SqlServer triggers through migrations using EFCore entity builder.</Description>
     <RepositoryUrl>https://github.com/win7user10/Laraue.EfCoreTriggers</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Add .NET 9 Support and update MigrationsModelDiffer to work with EF Core 9 updates.

See #108 